### PR TITLE
Fix Capitalazation Issue

### DIFF
--- a/kernel/src/idt/idt.c
+++ b/kernel/src/idt/idt.c
@@ -1,5 +1,5 @@
 #include "../terminal/terminal.h"
-#include "../hal/hal.h"
+#include "../HAL/hal.h"
 #define IDT_SIZE 256
 
 extern void KiISRDivideBy0ErrorLoader();

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -5,7 +5,7 @@
 #include "limine.h"
 #include "superheader.h"
 #include "terminal/terminal.h"
-#include "hal/hal.h"
+#include "HAL/hal.h"
 #include "driver/ps2/ps2.h"
 
 __attribute__((used, section(".limine_requests")))


### PR DESCRIPTION
Fixed a capitalation issue in kernel/src/main.c and kernel/src/idt/idt.c to work on *nix systems 